### PR TITLE
Make urllib and string literal prefixes work on both py2 and py3.

### DIFF
--- a/gravtr/__init__.py
+++ b/gravtr/__init__.py
@@ -1,9 +1,9 @@
 import hashlib
 import sys
 if sys.version_info[0] < 3:
-  import urllib
+    import urllib
 else:
-  import urllib.parse as urllib
+    import urllib.parse as urllib
 
 class Gravtr(object):
     GRAVATAR_URL = 'https://www.gravatar.com/avatar/'

--- a/gravtr/__init__.py
+++ b/gravtr/__init__.py
@@ -1,5 +1,9 @@
 import hashlib
-import urllib
+import sys
+if sys.version_info[0] < 3:
+  import urllib
+else:
+  import urllib.parse as urllib
 
 class Gravtr(object):
     GRAVATAR_URL = 'https://www.gravatar.com/avatar/'

--- a/tests.py
+++ b/tests.py
@@ -16,26 +16,26 @@ class GravtrTestCase(unittest.TestCase):
 
     def test_generate_url_with_specified_size_should_succeed(self):
         gravtr = Gravtr(email=self.email).generate(size=200)
-        assert re.search(ur"(\?|\&)s\=200", gravtr)
+        assert re.search(r"(\?|\&)s\=200", gravtr)
 
     def test_generate_url_with_type_should_succeed(self):
         gravtr = Gravtr(email=self.email).generate(typed=True, size=200)
-        assert re.search(ur"\.jpg", gravtr)
+        assert re.search(r"\.jpg", gravtr)
 
     def test_generate_url_with_default_should_succeed(self):
         default_image = 'http://example.com/image.jpg'
         gravtr = Gravtr(email=self.email).generate(default=default_image, size=200)
-        assert re.search(ur"(\?|\&)d\=http\%3A\%2F\%2Fexample\.com\%2Fimage\.jpg", gravtr)
+        assert re.search(r"(\?|\&)d\=http\%3A\%2F\%2Fexample\.com\%2Fimage\.jpg", gravtr)
 
     def test_generate_url_with_force_default_should_succeed(self):
         default_image = 'http://example.com/image.jpg'
         gravtr = Gravtr(email=self.email).generate(default=default_image, force_default=True)
-        assert re.search(ur"(\?|\&)d\=http\%3A\%2F\%2Fexample\.com\%2Fimage\.jpg", gravtr)
-        assert re.search(ur"(\?|\&)f\=y", gravtr)
+        assert re.search(r"(\?|\&)d\=http\%3A\%2F\%2Fexample\.com\%2Fimage\.jpg", gravtr)
+        assert re.search(r"(\?|\&)f\=y", gravtr)
 
     def test_generate_url_with_rating_type_should_succeed(self):
         gravtr = Gravtr(email=self.email).generate(typed=True, rating_type=Gravtr.ratingType.X)
-        assert re.search(ur"(\?|\&)r\=x", gravtr)
+        assert re.search(r"(\?|\&)r\=x", gravtr)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The build was failing on python3. It should work now.